### PR TITLE
Add nbviewer and license badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ Content is maintained on [github](github.com/dkirkby/MachineLearningStatistics) 
 The notebooks contain exercises but you will need to enable the [exercise2 extension](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/tree/master/src/jupyter_contrib_nbextensions/nbextensions/exercise2) to hide the solutions while you work on them, as described in the [setup instructions](notebooks/Setup.ipynb). All solutions are visible if you view notebooks on github.
 
 Instructors are welcome to contact dkirkby at uci.edu for access to additional material or to discuss collaboration.
+
+[![license](https://img.shields.io/github/license/dkirkby/MachineLearningStatistics.svg)]() [![nbviewer](https://img.shields.io/badge/view%20on-nbviewer-brightgreen.svg)](http://nbviewer.jupyter.org/github/dkirkby/MachineLearningStatistics/tree/master/notebooks/)

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ The notebooks contain exercises but you will need to enable the [exercise2 exten
 
 Instructors are welcome to contact dkirkby at uci.edu for access to additional material or to discuss collaboration.
 
-[![license](https://img.shields.io/github/license/dkirkby/MachineLearningStatistics.svg)]() [![nbviewer](https://img.shields.io/badge/view%20on-nbviewer-brightgreen.svg)](http://nbviewer.jupyter.org/github/dkirkby/MachineLearningStatistics/tree/master/notebooks/)
+[![license](https://img.shields.io/github/license/dkirkby/MachineLearningStatistics.svg)]() [![nbviewer](https://img.shields.io/badge/view%20on-nbviewer-brightgreen.svg)](http://nbviewer.jupyter.org/github/dkirkby/MachineLearningStatistics/tree/master/notebooks/Contents.ipynb)


### PR DESCRIPTION
The nbviewer badge added to the README is hyperlinked to the [nbviewer page for the MachineLearningStatistics repo](http://nbviewer.jupyter.org/github/dkirkby/MachineLearningStatistics/tree/master/notebooks/). This makes it easier to view the notebooks as a set of nicely rendered notes in browser (as compared to the view of the notebook that GitHub offers).